### PR TITLE
Correct CURA detection

### DIFF
--- a/octoprint_printhistory/parser.py
+++ b/octoprint_printhistory/parser.py
@@ -44,9 +44,9 @@ class CuraParser(BaseParser):
 
     def detect(self, gcode_file):
         detected = False
-        # on the third line
+        # on the third line (not always)
         # ;Generated with Cura_SteamEngine 2.3.1
-        for _ in range(3):
+        for _ in range(10):
             line = gcode_file.readline()
             if re.search(r"Cura_SteamEngine", line):
                 detected = True


### PR DESCRIPTION
I've checked that it correctly detects [WDI_elf_ranger_supports.gcode.gz](https://github.com/imrahil/OctoPrint-PrintHistory/files/819390/WDI_elf_ranger_supports.gcode.gz)

Fixes #48 

p.s. Need to refactor parser, it shouldn't fail if nothing detected.