### PR TITLE
Fix failing when parser isn't detected.

### DIFF
--- a/octoprint_printhistory/eventHandler.py
+++ b/octoprint_printhistory/eventHandler.py
@@ -42,7 +42,7 @@ def eventHandler(self, event, payload):
             success = None
             estimatedPrintTime = 0
 
-            gcode_parser = UniversalParser(payload["file"])
+            gcode_parser = UniversalParser(payload["file"], logger=self._logger)
             parameters = gcode_parser.parse()
             currentFile = {
                 "fileName": fileName,


### PR DESCRIPTION
Should it log with info level or warn?
```
2017-03-06 11:41:43,434 - octoprint.plugins.printhistory - INFO - Can't parse additional parameters from /home/user/.octoprint/uploads/undetected.gcode
```