### PR TITLE
Fix Cura version parsing error

### DIFF
--- a/octoprint_printhistory/parser.py
+++ b/octoprint_printhistory/parser.py
@@ -55,8 +55,10 @@ class CuraParser(BaseParser):
         for _ in range(10):
             line = gcode_file.readline()
             if re.search(r"Cura_SteamEngine", line):
-                detected = True
-                self.version = VERSION_REGEX.search(line).group(0)
+                version = VERSION_REGEX.search(line)
+                if version:
+                    detected = True
+                    self.version = version.group(0)
         gcode_file.seek(0)
         return detected
 


### PR DESCRIPTION
If parsing of version fails, Gcode file should still be added to history. 

Example of bad Cura version line:
` ;Generated with Cura_SteamEngine master`

Fixes errors like this one:

```
2017-11-24 03:19:40,418 - octoprint.plugin - ERROR - Error while calling plugin printhistory
Traceback (most recent call last):
  File "/home/pi/OctoPrint/1.3.5/venv/local/lib/python2.7/site-packages/OctoPrint-1.3.5-py2.7.egg/octoprint/plugin/__init__.py", line 235, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/pi/OctoPrint/1.3.5/venv/local/lib/python2.7/site-packages/octoprint_printhistory/__init__.py", line 146, in on_event
    return eventHandler.eventHandler(self, event, payload)
  File "/home/pi/OctoPrint/1.3.5/venv/local/lib/python2.7/site-packages/octoprint_printhistory/eventHandler.py", line 45, in eventHandler
    gcode_parser = UniversalParser(payload["file"], logger=self._logger)
  File "/home/pi/OctoPrint/1.3.5/venv/local/lib/python2.7/site-packages/octoprint_printhistory/parser.py", line 21, in __init__
    if parser.detect(self.file):
  File "/home/pi/OctoPrint/1.3.5/venv/local/lib/python2.7/site-packages/octoprint_printhistory/parser.py", line 59, in detect
    self.version = VERSION_REGEX.search(line).group(0)
AttributeError: 'NoneType' object has no attribute 'group'

```