### PR TITLE
Correct references for payload name

### DIFF
--- a/octoprint_printhistory/__init__.py
+++ b/octoprint_printhistory/__init__.py
@@ -175,9 +175,9 @@ class PrintHistoryPlugin(octoprint.plugin.StartupPlugin,
 
             import hashlib
             hash = hashlib.sha1()
-	    if sys.version_info >= (3,0):
+            if sys.version_info >= (3,0):
                 hash.update(str(lm).encode())
-	    else:
+            else:
                 hash.update(str(lm))
             hexdigest = hash.hexdigest()
             return hexdigest

--- a/octoprint_printhistory/eventHandler.py
+++ b/octoprint_printhistory/eventHandler.py
@@ -41,6 +41,9 @@ def eventHandler(self, event, payload):
             timestamp = 0
             success = None
             estimatedPrintTime = 0
+            self._logger.info("Origin: "+ payload["origin"])
+            self._logger.info("Path: "+ payload["path"])
+            self._logger.info("Path_On_disk: "+ self._file_manager.path_on_disk(payload["origin"], payload["path"]))
             gcode_parser = UniversalParser(self._file_manager.path_on_disk(payload["origin"], payload["path"]), logger=self._logger)
             parameters = gcode_parser.parse()
             currentFile = {
@@ -48,7 +51,7 @@ def eventHandler(self, event, payload):
                 "note": "",
                 "parameters": json.dumps(parameters)
             }
-
+            self._logger.info(json.dumps(parameters))
             # analysis - looking for info about filament usage
             if "analysis" in fileData:
                 if "filament" in fileData["analysis"]:

--- a/octoprint_printhistory/eventHandler.py
+++ b/octoprint_printhistory/eventHandler.py
@@ -31,7 +31,7 @@ def eventHandler(self, event, payload):
 
     if supported_event is not Events.METADATA_STATISTICS_UPDATED:
         try:
-            fileData = self._file_manager.get_metadata(payload["origin"], payload["file"])
+            fileData = self._file_manager.get_metadata(payload["origin"], payload["name"])
         except:
             fileData = None
 
@@ -41,8 +41,7 @@ def eventHandler(self, event, payload):
             timestamp = 0
             success = None
             estimatedPrintTime = 0
-
-            gcode_parser = UniversalParser(payload["file"], logger=self._logger)
+            gcode_parser = UniversalParser(self._file_manager.path_on_disk(payload["origin"], payload["path"]), logger=self._logger)
             parameters = gcode_parser.parse()
             currentFile = {
                 "fileName": fileName,


### PR DESCRIPTION
Following the fix suggested in: https://github.com/imrahil/OctoPrint-PrintHistory/issues/86
I implemented it and tested locally and it works perfectly.
My install of the plug in stopped working on april and after reinstalling with this change it started working again:
![image](https://user-images.githubusercontent.com/16392849/119397930-376a2780-bcad-11eb-930e-8d8efb116e47.png)
