### PR TITLE
Fixes to export options

### DIFF
--- a/octoprint_printhistory/export.py
+++ b/octoprint_printhistory/export.py
@@ -9,6 +9,7 @@ def exportHistoryData(self, exportType):
     import sys
     if sys.version_info >= (3,0):
         from io import StringIO
+        from io import BytesIO
         import csv
     else:
         from StringIO import StringIO
@@ -88,6 +89,9 @@ def exportHistoryData(self, exportType):
             response.headers["Content-Disposition"] = "attachment; filename=octoprint_print_history(extra)_export.csv"
         elif exportType == 'excel':
             import xlsxwriter
+
+            if sys.version_info >= (3,0):
+                si = BytesIO()
 
             workbook = xlsxwriter.Workbook(si)
             worksheet = workbook.add_worksheet()

--- a/octoprint_printhistory/utils.py
+++ b/octoprint_printhistory/utils.py
@@ -20,7 +20,7 @@ def rename_duplicates(immutable, mutable, prefix):
     """
     for value in mutable:
         if value in immutable:
-            mutable[mutable.index(value)] = str(prefix) + value
+            value = str(prefix) + value
     return mutable
 
 def namedtuple_with_defaults(typename, field_names, default_values=()):
@@ -29,7 +29,7 @@ def namedtuple_with_defaults(typename, field_names, default_values=()):
     """
     T = collections.namedtuple(typename, field_names)
     T.__new__.__defaults__ = (None,) * len(T._fields)
-    if isinstance(default_values, collections.Mapping):
+    if isinstance(default_values, collections.abc.Mapping):
         prototype = T(**default_values)
     else:
         prototype = T(*default_values)
@@ -40,6 +40,6 @@ def load_json(dictionary, key):
     parameters_json = dictionary.get(key)
     try:
         parameters = json.loads(parameters_json)
-    except ValueError:
+    except:
         parameters = {}
     return parameters


### PR DESCRIPTION
Hello,

I was experiencing a few errors when trying to use the export options so I tried fixing them myself. I am not very experienced with python, I just kept following the errors and making changes that seem fix things.

To me it looks like later versions of python caused compatibility issues leading to most of the problems. The changes I made are as follows:
* xlsxwriter does not accept ```StringIO``` anymore - to fix I changed to ```BytesIO```
* ```collections.Mapping``` does not work anymore - to fix I changed it to ```collections.abc.Mapping```
* ```parameters = json.loads(parameters_json)``` was returning a ```TypeError``` so I just made it an except all


Please take a look and let me know what you think. I am open to friendly suggestions and advice.

Thanks