### PR TITLE
Fix excel export

### DIFF
--- a/octoprint_printhistory/export.py
+++ b/octoprint_printhistory/export.py
@@ -127,7 +127,7 @@ def formatPrintTime(valueInSeconds):
          tmp = tmp % 60
          seconds = int(tmp)
          
-         return str(hours).zfill(3) + ":" + str(minutes).zfill(2) + ":" + str(seconds).zfill(2)
+         return str(hours) + ":" + str(minutes).zfill(2) + ":" + str(seconds).zfill(2)
      else:
          return "-"
 


### PR DESCRIPTION
Addresses: https://github.com/imrahil/OctoPrint-PrintHistory/issues/95

From what I can tell the leading 0's are causing the problem. I fixed this by simply removing the zfill function on that value.

I tested this and it looked fine on my end but please check on yours as well

Thanks